### PR TITLE
Create active indexes where possible.

### DIFF
--- a/src/jepsen/faunadb/bank.clj
+++ b/src/jepsen/faunadb/bank.clj
@@ -148,6 +148,7 @@
       (client/setup! bank-client test)
       (f/upsert-index! conn {:name idx-name
                              :source accounts
+                             :active true
                              :serialized (boolean (:serialized-indices test))
                              :values [{:field ["ref"]}
                                       {:field ["data" "balance"]}]})

--- a/src/jepsen/faunadb/g2.clj
+++ b/src/jepsen/faunadb/g2.clj
@@ -41,10 +41,12 @@
       (f/upsert-class! conn {:name b-name})
       (f/upsert-index! conn {:name a-index-name
                              :source a
+                             :active true
                              :serialized (boolean (:serialized-indices test))
                              :terms [{:field ["data" "key"]}]})
       (f/upsert-index! conn {:name b-index-name
                              :source b
+                             :active true
                              :serialized (boolean (:serialized-indices test))
                              :terms [{:field ["data" "key"]}]})
       (f/wait-for-index conn a-index)

--- a/src/jepsen/faunadb/internal.clj
+++ b/src/jepsen/faunadb/internal.clj
@@ -62,6 +62,7 @@
       (f/upsert-class! conn {:name cats-name})
       (f/upsert-index! conn {:name index-name
                              :source cats
+                             :active true
                              :serialized (boolean (:serialized-indices test))
                              :terms [{:field ["data" "type"]}]
                              :values [{:field ["ref"]}

--- a/src/jepsen/faunadb/pages.clj
+++ b/src/jepsen/faunadb/pages.clj
@@ -34,6 +34,7 @@
       (f/upsert-class! conn {:name elements-name})
       (f/upsert-index! conn {:name        idx-name
                              :source      elements
+                             :active      true
                              :serialized  (boolean
                                             (:serialized-indices test))
                              ; :partitions 1

--- a/src/jepsen/faunadb/set.clj
+++ b/src/jepsen/faunadb/set.clj
@@ -27,6 +27,7 @@
       (f/upsert-class! conn {:name side-effects})
       (f/upsert-index! conn {:name       idx-name
                              :source     (q/class elements)
+                             :active     true
                              :serialized (boolean (:serialized-indices test))
                              :values     [{:field ["data" "value"]}]})
       (f/wait-for-index conn idx)))


### PR DESCRIPTION
Versions of FaunaDB >= 2.6.1 allow active index creation. Versions < 2.6.1 will ignore the field and wait for index activation as before.